### PR TITLE
Add nsheff as recipe maintainer

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -39,3 +39,4 @@ extra:
   recipe-maintainers:
     - stolarczyk
     - khoroshevskyi
+    - nsheff


### PR DESCRIPTION
Adding myself as a maintainer for the logmuse feedstock. I am the upstream maintainer of logmuse at https://github.com/databio/logmuse.